### PR TITLE
Updated to support VS11-VS12

### DIFF
--- a/Source/Machine.VSTestAdapter/Machine.VSTestAdapter.csproj
+++ b/Source/Machine.VSTestAdapter/Machine.VSTestAdapter.csproj
@@ -41,7 +41,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
-      <HintPath>..\Microsoft.VisualStudio.TestPlatform.ObjectModel Binaries\VS14Update1\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>..\Microsoft.VisualStudio.TestPlatform.ObjectModel Binaries\VS11\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>


### PR DESCRIPTION
By binding the `TestPlatform.ObjectModel` reference to VS14, the adapter
will no longer work in VS11-12
