### PR TITLE
[Feature] Pass behavior type to dotnet test runner

### DIFF
--- a/Source/Machine.VSTestAdapter.Specs/Discovery/BuiltIn/When_discovering_behaviors.cs
+++ b/Source/Machine.VSTestAdapter.Specs/Discovery/BuiltIn/When_discovering_behaviors.cs
@@ -19,5 +19,14 @@ namespace Machine.VSTestAdapter.Specs.Discovery.BuiltIn
             discoveredSpec.LineNumber.ShouldEqual(14);
             discoveredSpec.CodeFilePath.EndsWith("BehaviorSample.cs", StringComparison.Ordinal);
         };
+
+        It should_pick_up_the_behavior_field_type_and_name = () => {
+            MSpecTestCase discoveredSpec = Results.SingleOrDefault(x => "sample_behavior_test".Equals(x.SpecificationName, StringComparison.Ordinal) &&
+                                                                        "BehaviorSampleSpec".Equals(x.ClassName, StringComparison.Ordinal));
+            discoveredSpec.ShouldNotBeNull();
+
+            discoveredSpec.BehaviorFieldName.ShouldEqual("some_behavior");
+            discoveredSpec.BehaviorFieldType.ShouldEqual("SampleSpecs.SampleBehavior");
+        };
     }
 }

--- a/Source/Machine.VSTestAdapter.Specs/Machine.VSTestAdapter.Specs.csproj
+++ b/Source/Machine.VSTestAdapter.Specs/Machine.VSTestAdapter.Specs.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Machine.Fakes.Moq" Version="2.8.0" />
-    <PackageReference Include="Machine.Specifications" Version="0.11.0" />
+    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
     <PackageReference Include="Machine.Specifications.Should" Version="0.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" Condition="'$(TargetFramework)'=='netstandard1.5'" />

--- a/Source/Machine.VSTestAdapter/Discovery/BuiltIn/TestDiscoverer.cs
+++ b/Source/Machine.VSTestAdapter/Discovery/BuiltIn/TestDiscoverer.cs
@@ -58,7 +58,7 @@ namespace Machine.VSTestAdapter.Discovery.BuiltIn
                 }
 
                 if (spec is BehaviorSpecification behaviorSpec)
-                    testCase.BehaviorFieldName = GetBehaviorFieldName(behaviorSpec);
+                    PopulateBehaviorField(testCase, behaviorSpec);
 
                 if (context.Tags != null)
                     testCase.Tags = context.Tags.Select(tag => tag.Name).ToArray();
@@ -70,12 +70,13 @@ namespace Machine.VSTestAdapter.Discovery.BuiltIn
             }
         }
 
-        private string GetBehaviorFieldName(BehaviorSpecification specification)
+        private void PopulateBehaviorField(MSpecTestCase testCase, BehaviorSpecification specification)
         {
             if (behaviorProperty?.GetValue(specification) is FieldInfo field)
-                return field.Name;
-
-            return string.Empty;
+            {
+                testCase.BehaviorFieldName = field.Name;
+                testCase.BehaviorFieldType = field.FieldType.GenericTypeArguments.FirstOrDefault()?.FullName;
+            }
         }
 
         private string GetContextDisplayName(Type contextType)

--- a/Source/Machine.VSTestAdapter/Discovery/MSpecTestCase.cs
+++ b/Source/Machine.VSTestAdapter/Discovery/MSpecTestCase.cs
@@ -17,6 +17,7 @@ namespace Machine.VSTestAdapter.Discovery
         public string SpecificationDisplayName { get; set; }
         public string SpecificationName { get; set; }
         public string BehaviorFieldName { get; set; }
+        public string BehaviorFieldType { get; set; }
 
         public string CodeFilePath { get; set; }
 

--- a/Source/Machine.VSTestAdapter/Helpers/SpecTestHelper.cs
+++ b/Source/Machine.VSTestAdapter/Helpers/SpecTestHelper.cs
@@ -39,6 +39,9 @@ namespace Machine.VSTestAdapter.Helpers
             if (!string.IsNullOrEmpty(mspecTestCase.BehaviorFieldName))
                 testCase.Traits.Add(new Trait(Strings.TRAIT_BEHAVIOR, mspecTestCase.BehaviorFieldName));
 
+            if (!string.IsNullOrEmpty(mspecTestCase.BehaviorFieldType))
+                testCase.Traits.Add(new Trait(Strings.TRAIT_BEHAVIOR_TYPE, mspecTestCase.BehaviorFieldType));
+
             Debug.WriteLine($"TestCase {testCase.FullyQualifiedName}");
             return testCase;
         }

--- a/Source/Machine.VSTestAdapter/Strings.Designer.cs
+++ b/Source/Machine.VSTestAdapter/Strings.Designer.cs
@@ -152,6 +152,15 @@ namespace Machine.VSTestAdapter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to BehaviorType.
+        /// </summary>
+        internal static string TRAIT_BEHAVIOR_TYPE {
+            get {
+                return ResourceManager.GetString("TRAIT_BEHAVIOR_TYPE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ClassName.
         /// </summary>
         internal static string TRAIT_CLASS {

--- a/Source/Machine.VSTestAdapter/Strings.resx
+++ b/Source/Machine.VSTestAdapter/Strings.resx
@@ -147,6 +147,9 @@
   <data name="TRAIT_BEHAVIOR" xml:space="preserve">
     <value>BehaviorField</value>
   </data>
+  <data name="TRAIT_BEHAVIOR_TYPE" xml:space="preserve">
+    <value>BehaviorType</value>
+  </data>
   <data name="TRAIT_CLASS" xml:space="preserve">
     <value>ClassName</value>
   </data>

--- a/Source/SampleSpecs/SampleSpecs.csproj
+++ b/Source/SampleSpecs/SampleSpecs.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Machine.Specifications" Version="0.11.0" />
+    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
     <PackageReference Include="Machine.Specifications.Should" Version="0.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
   </ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
-  nuget_version: '2.4.0'
+  nuget_version: '2.5.0'
   nuget_prerelease: false
  # vsix_version: '2.1.0'
-  assembly_version: '2.4.0'
+  assembly_version: '2.5.0'
 
 version: '$(nuget_version)+{build}'
 


### PR DESCRIPTION
@ivanz I'm so sorry, we need the behavior type as well as the field name 😢! I picked this up when testing the R# dotnet core provider, where the navigation to the behavior spec is broken. I should have been more thorough when we I was checking the pre-release version.

I've also added some tests around this as well.