### PR TITLE
[Bug] Fix tests not found in dotnet core projects/out of memory

### DIFF
--- a/Source/Machine.VSTestAdapter/Discovery/BuiltIn/TestDiscoverer.cs
+++ b/Source/Machine.VSTestAdapter/Discovery/BuiltIn/TestDiscoverer.cs
@@ -24,9 +24,10 @@ namespace Machine.VSTestAdapter.Discovery.BuiltIn
             Assembly assembly = AssemblyHelper.Load(assemblyPath);
             IEnumerable<Context> contexts = assemblyExplorer.FindContextsIn(assembly);
 
-            SourceCodeLocationFinder locationFinder = new SourceCodeLocationFinder(assemblyPath);
-
-            return contexts.SelectMany(context => CreateTestCase(context, locationFinder)).ToList();
+            using (SourceCodeLocationFinder locationFinder = new SourceCodeLocationFinder(assemblyPath))
+            {
+                return contexts.SelectMany(context => CreateTestCase(context, locationFinder)).ToList();
+            }
         }
 
         private IEnumerable<MSpecTestCase> CreateTestCase(Context context, SourceCodeLocationFinder locationFinder)

--- a/Source/Machine.VSTestAdapter/Machine.VSTestAdapter.csproj
+++ b/Source/Machine.VSTestAdapter/Machine.VSTestAdapter.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
     <DefineConstants>NETSTANDARD</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="[0.10-*, 0.11)" />
     <PackageReference Include="Machine.Specifications" Version="[0.11.0, 1.0)">

--- a/Source/Machine.VSTestAdapter/Machine.VSTestAdapter.csproj
+++ b/Source/Machine.VSTestAdapter/Machine.VSTestAdapter.csproj
@@ -12,7 +12,7 @@
     <Product>Machine.Specifications.Runner.VisualStudio</Product>
     <AssemblyTitle>Machine.Specifications.Runner.VisualStudio</AssemblyTitle>
     <PackageId>Machine.Specifications.Runner.VisualStudio </PackageId>
-    <Version>2.0.0</Version>
+    <Version>1.0.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Authors>https://github.com/machine/machine.vstestadapter</Authors>
     <PackageProjectUrl>https://github.com/machine/machine.vstestadapter</PackageProjectUrl>

--- a/Source/Machine.VSTestAdapter/Machine.VSTestAdapter.csproj
+++ b/Source/Machine.VSTestAdapter/Machine.VSTestAdapter.csproj
@@ -12,7 +12,7 @@
     <Product>Machine.Specifications.Runner.VisualStudio</Product>
     <AssemblyTitle>Machine.Specifications.Runner.VisualStudio</AssemblyTitle>
     <PackageId>Machine.Specifications.Runner.VisualStudio </PackageId>
-    <Version>1.0.0</Version>
+    <Version>2.0.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Authors>https://github.com/machine/machine.vstestadapter</Authors>
     <PackageProjectUrl>https://github.com/machine/machine.vstestadapter</PackageProjectUrl>
@@ -25,24 +25,23 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
     <DefineConstants>NETSTANDARD</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'==$(_TargetDotNetCore)">
+  
+  <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="[0.10-*, 0.11)" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="[15.0.0,16)">
-      <PrivateAssets>All</PrivateAssets> <!-- Only a reference during build/dev time -->
-    </PackageReference>
     <PackageReference Include="Machine.Specifications" Version="[0.11.0, 1.0)">
       <PrivateAssets>All</PrivateAssets>
       <!-- Only a reference during build/dev time -->
     </PackageReference>
   </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)'=='$(_TargetDotNetFramework)'">
-    <PackageReference Include="Mono.Cecil" Version="0.9.6.1" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="[11.0.0,16.0.0)">
+
+  <ItemGroup Condition="'$(TargetFramework)'==$(_TargetDotNetCore)">
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="[15.0.0,16)">
       <PrivateAssets>All</PrivateAssets> <!-- Only a reference during build/dev time -->
     </PackageReference>
-    <PackageReference Include="Machine.Specifications" Version="[0.11.0, 1.0)">
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)'=='$(_TargetDotNetFramework)'">
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="[11.0.0,16.0.0)">
       <PrivateAssets>All</PrivateAssets> <!-- Only a reference during build/dev time -->
     </PackageReference>
   </ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  nuget_version: '2.6.1'
-  assembly_version: '2.6.1'
+  nuget_version: '2.7.0'
+  assembly_version: '2.7.0'
 
 version: '$(nuget_version)+{build}'
 
@@ -28,7 +28,7 @@ test_script: dotnet test -c %CONFIGURATION% Source\Machine.VSTestAdapter.Specs
 deploy:
   - provider: GitHub
     description: |
-      * Fix to support for VS 2017 15.5.x
+      * Fix for out ot memory exceptions and tests not showing up
 
     on:
       appveyor_repo_tag: true


### PR DESCRIPTION
The issue was that the older version of Mono.Cecil was throwing weird `OutOfMemoryExceptions` for assemblies that were built using the new csproj format. This was happening silently and preventing tests from showing up in the test explorer window. 

I think this is the correct fix, now that Mono.Cecil is out of beta, it should be a smooth upgrade.

Issues that I think this addresses:
- #80
- #78
- https://github.com/machine/machine.specifications/issues/348

Paging @ivanz 